### PR TITLE
Adopt Central Package Management for NuGet dependencies

### DIFF
--- a/Directory.Packages.Props
+++ b/Directory.Packages.Props
@@ -1,0 +1,31 @@
+<Project>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.50" />
+		<PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
+		<PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
+		<PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.0" />
+		<PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.16.0" />
+		<PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" />
+		<PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+		<PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
+		<PackageVersion Include="Microsoft.IdentityModel.Logging" Version="6.35.0" />
+		<PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.5.1" />
+		<PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
+		<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.3" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+		<PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.8" />
+		<PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
+		<PackageVersion Include="coverlet.collector" Version="6.0.0" />
+		<PackageVersion Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageVersion Include="NSubstitute" Version="5.1.0" />
+		<PackageVersion Include="xunit" Version="2.5.3" />
+		<PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+	</ItemGroup>
+</Project>

--- a/TableOfUDTOracle.sln
+++ b/TableOfUDTOracle.sln
@@ -30,6 +30,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{55FE
 		..\..\..\Documents\Requests PLSQL\TYPE_DEMANDE_REC.pls = ..\..\..\Documents\Requests PLSQL\TYPE_DEMANDE_REC.pls
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.Props = Directory.Packages.Props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/TableOfUdtOracle.API/TableOfUdtOracle.Functions.API.csproj
+++ b/src/TableOfUdtOracle.API/TableOfUdtOracle.Functions.API.csproj
@@ -8,18 +8,18 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.16.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.35.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http"  />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore"  />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus"  />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk"  />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" />
+    <PackageReference Include="Microsoft.IdentityModel.Logging" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/TableOfUdtOracle.Domain/TableOfUdtOracle.Domain.csproj
+++ b/src/TableOfUdtOracle.Domain/TableOfUdtOracle.Domain.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Oracle.EntityFrameworkCore" Version="8.23.50" />
+    <PackageReference Include="Oracle.EntityFrameworkCore" />
   </ItemGroup>
 
 </Project>

--- a/src/TableOfUdtOracle.Infrastructure/TableOfUdtOracle.Infrastructure.csproj
+++ b/src/TableOfUdtOracle.Infrastructure/TableOfUdtOracle.Infrastructure.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.8" />
-    <PackageReference Include="Oracle.EntityFrameworkCore" Version="8.23.50" />
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks"  />
+    <PackageReference Include="Oracle.EntityFrameworkCore" />
+    <PackageReference Include="System.Formats.Asn1"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/TableOfUdtOracleUnitTests/AddRequestFromMessageFunctionUnitTests.cs
+++ b/tests/TableOfUdtOracleUnitTests/AddRequestFromMessageFunctionUnitTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.TestPlatform.TestHost;
 using Newtonsoft.Json;
 using NSubstitute;
 using Oracle.ManagedDataAccess.Client;
-using System.Diagnostics;
 using System.Text;
 using TableOfUdtOracle.ApplicationCore.Dtos.Requests;
 using TableOfUdtOracle.ApplicationCore.Services;

--- a/tests/TableOfUdtOracleUnitTests/TableOfUdtOracleUnitTests.csproj
+++ b/tests/TableOfUdtOracleUnitTests/TableOfUdtOracleUnitTests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Introduce Directory.Packages.Props for centralized NuGet version management. Remove explicit version numbers from all project files and update the solution to include the new props file. Also, remove a redundant using directive. This streamlines dependency updates and ensures consistency across the solution.

WIP: Code refactoring.